### PR TITLE
Remove statement saying this has 3 times shorter code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A Device Tree is a data structure for describing hardware. They are used in a lo
 ARM devices (e.g. Android), otherwise these would not be able to boot.
 
 This tool is similar to [split-appended-dtb](https://github.com/dianlujitao/split-appended-dtb)
-but it is written in Python and its code is simpler and almost 3x shorter. Moreover, it doesn't
-require any external Python library.
+but it is written in Python and its code is simpler. Moreover, it doesn't require any external
+Python library.
 
 If you want to learn more about DTB you can have a look at the
 [Device Tree Reference](http://elinux.org/Device_Tree_Reference).


### PR DESCRIPTION
This may have been true at the time of writing,
but at this point extract-dtb's code is very
similar in size to split-appended-dtb's code.